### PR TITLE
rpn: Add additional bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,11 @@ The global shortcuts work from everywhere, regardless of the currently focused v
 ### Input
 | Key                          | Function                                                                |
 |------------------------------|-------------------------------------------------------------------------|
-| <kbd>left</kbd>              | Move cursor left                                                        |
-| <kbd>right</kbd>             | Move cursor right                                                       |
+| <kbd>left</kbd>              | Move cursor left; if empty: roll up                                     |
+| <kbd>right</kbd>             | Move cursor right; if empty: roll down                                  |
 | <kbd>up</kbd>                | Focus stack                                                             |
 | <kbd>down</kbd>              | Swap stack 1 & 2                                                        |
+| <kbd>enter</kbd>             | Submit input; if empty: dup 1                                           |
 | <kbd>return</kbd>            | Insert special character/operator                                       |
 | <kbd>tab</kbd>               | Start completion for current input                                      |
 | <kbd>G</kbd><kbd>left</kbd>  | Go to beginning                                                         |

--- a/rpn.lua
+++ b/rpn.lua
@@ -2742,8 +2742,12 @@ function KeybindManager:dispatchKey(key)
 
   -- Call binding
   if type(self.currentTab) == 'function' then
-    if self.currentTab(self.currentSequence) == 'repeat' then
+    local action = self.currentTab(self.currentSequence)
+    if action == 'repeat' then
       self.currentTab = {[key] = self.currentTab}
+    elseif action == 'none' then
+      self:resetSequence()
+      return false
     else
       self:resetSequence()
     end
@@ -3844,6 +3848,22 @@ function UIInput:init_bindings()
     end)
   end
 
+  self.kbd:setSequence({'enter'}, function()
+    if self.text:ulen() > 0 then return 'none' end
+    StackView:dup()
+  end)
+  self.kbd:setSequence({'left'}, function()
+    if self.text:ulen() > 0 then return 'none' end
+    StackView:roll(-1)
+  end)
+  self.kbd:setSequence({'right'}, function()
+    if self.text:ulen() > 0 then return 'none' end
+    StackView:roll(1)
+  end)
+  self.kbd:setSequence({'down'}, function()
+    StackView:swap()
+  end)
+
   self.kbd:setSequence({'.', '%d'}, function(sequence)
     local n = tonumber(sequence[#sequence])
     self:insertText('.' .. n)
@@ -4124,10 +4144,6 @@ function UIInput:onArrowRight()
   self:invalidate()
 end
 
-function UIInput:onArrowDown()
-  StackView:swap()
-end
-
 function UIInput:onArrowUp()
   focus_view(StackView)
 end
@@ -4270,7 +4286,6 @@ function UIInput:onEnter()
   if self.text:ulen() == 0 then return end
 
   self.inputHandler:onEnter()
-
   self.tempMode = nil
 end
 


### PR DESCRIPTION
Adds the following bindings if input is empty:
- `enter` duplicate top stack entry
- `left` roll up
- `right` roll down